### PR TITLE
build: changed publish action to be triggered when release is published

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,8 @@ jobs:
           - name: Check if benchmark_results.png has changed 🔍
             id: check_benchmark
             run: |
-              git diff --name-only $(git rev-parse ${{ github.ref }} 2>/dev/null || echo "") | grep '^assets/benchmark_results.png$' || true
-              echo "::set-output name=changed::$?"
+              git fetch origin main
+              git merge-base origin/main HEAD
 
           - name: Post comment with benchmark results 📝
             if: steps.check_benchmark.outputs.changed == '0'
@@ -125,8 +125,14 @@ jobs:
       - name: Check if VERSION file has changed 🔍
         id: check_version
         run: |
-          git diff --name-only $(git rev-parse ${{ github.ref }} 2>/dev/null || echo "") | grep '^VERSION$' || true
-          echo "::set-output name=changed::$?"
+          git fetch origin main
+          merge_base=$(git merge-base origin/main HEAD)
+          if git diff --name-only $merge_base HEAD | grep -q '^VERSION$'; then
+            echo "::set-output name=changed::0"
+          else
+            echo "::set-output name=changed::1"
+          fi
+          exit 0
 
       - name: Get version from VERSION file 💻
         id: get_version
@@ -141,4 +147,4 @@ jobs:
           draft: false
           prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
             fail-fast: false
             matrix:
               python-version:
-                # - "3.8"
-                # - "3.9"
+                - "3.8"
+                - "3.9"
                 - "3.10"
               os:
                 - ubuntu-latest
-                # - windows-latest
-                # - macos-latest
+                - windows-latest
+                - macos-latest
               arch:
                 - x64
         steps:
@@ -63,12 +63,19 @@ jobs:
           - name: Checkout code 📂
             uses: actions/checkout@v3
 
+          - name: Get changed files 🔄
+            id: changed_files
+            uses: tj-actions/changed-files@v35
+
           - name: Check if benchmark_results.png has changed 🔍
             id: check_benchmark
             run: |
-              base_branch=$(echo ${{ github.event.pull_request.base.ref }})
-              git fetch origin $base_branch
-              merge_base=$(git merge-base origin/$base_branch HEAD)
+              echo "::set-output name=changed::1"
+              for file in ${{ steps.changed_files.outputs.all_changed_files }}; do
+                if [ $file = "assets/benchmark_results.png" ]; then
+                  echo "::set-output name=changed::0"
+                fi
+              done
 
           - name: Post comment with benchmark results 📝
             if: steps.check_benchmark.outputs.changed == '0'
@@ -123,19 +130,19 @@ jobs:
       - name: Checkout code 📂
         uses: actions/checkout@v3
 
+      - name: Get changed files 🔄
+        id: changed_files
+        uses: tj-actions/changed-files@v35
+
       - name: Check if VERSION file has changed 🔍
-        id: check_version
+        id: check_benchmark
         run: |
-          base_branch=${{ github.base_ref }}
-          git fetch origin $base_branch
-          merge_base=$(git merge-base origin/$base_branch HEAD)
-          if git diff --name-only $merge_base HEAD | grep -q '^VERSION$'; then
-            echo "::set-output name=changed::0"
-            exit 0
-          else
-            echo "::set-output name=changed::1"
-            exit 1
-          fi
+          echo "::set-output name=changed::1"
+          for file in ${{ steps.changed_files.outputs.all_changed_files }}; do
+            if [ $file = "VERSION" ]; then
+              echo "::set-output name=changed::0"
+            fi
+          done
 
       - name: Get version from VERSION file 💻
         id: get_version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
             fail-fast: false
             matrix:
               python-version:
-                - "3.8"
-                - "3.9"
+                # - "3.8"
+                # - "3.9"
                 - "3.10"
               os:
                 - ubuntu-latest
-                - windows-latest
-                - macos-latest
+                # - windows-latest
+                # - macos-latest
               arch:
                 - x64
         steps:
@@ -66,8 +66,9 @@ jobs:
           - name: Check if benchmark_results.png has changed 🔍
             id: check_benchmark
             run: |
-              git fetch origin main
-              git merge-base origin/main HEAD
+              base_branch=$(echo ${{ github.event.pull_request.base.ref }})
+              git fetch origin $base_branch
+              merge_base=$(git merge-base origin/$base_branch HEAD)
 
           - name: Post comment with benchmark results 📝
             if: steps.check_benchmark.outputs.changed == '0'
@@ -125,14 +126,16 @@ jobs:
       - name: Check if VERSION file has changed 🔍
         id: check_version
         run: |
-          git fetch origin main
-          merge_base=$(git merge-base origin/main HEAD)
+          base_branch=${{ github.base_ref }}
+          git fetch origin $base_branch
+          merge_base=$(git merge-base origin/$base_branch HEAD)
           if git diff --name-only $merge_base HEAD | grep -q '^VERSION$'; then
             echo "::set-output name=changed::0"
+            exit 0
           else
             echo "::set-output name=changed::1"
+            exit 1
           fi
-          exit 0
 
       - name: Get version from VERSION file 💻
         id: get_version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.1.1]
 
 ### Added
+
 - PolyGoneNMS library for efficient and distributed polygon Non-Maximum Suppression (NMS).
 - Support for different NMS methods: Default, Soft, and Class Agnostic.
 - Support for various intersection methods: IOU, IOS, and Dice.

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -16,6 +16,8 @@ def main():
     if "assets/benchmark_results.png" in output:
         benchmark_changed = True
 
+    if version_changed:
+        print("REMEMBER: Add changes to CHANGELOG.md")
     if version_changed and not benchmark_changed:
         print(
             "ERROR: The VERSION file has changed, "


### PR DESCRIPTION
This PR updates the publish action in our GitHub Actions workflow to be triggered when a new release is published. This change ensures that the package is published to PyPI only when a new release is created, providing better control over our release process and improving the overall project maintainability.
